### PR TITLE
edit/delete buttons only show for users

### DIFF
--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,6 +1,7 @@
 import CommentSection from '@/components/comments/commentSection';
 import Icon from '@/components/Icon';
 import { deletePost, getSinglePost } from '@/utils/data/postData';
+import { getCurrentUserId } from '@/utils/data/AuthManager';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -172,18 +173,20 @@ export default function ViewPost() {
                 </div>
               </Card.Body>
               {/* Post Actions */}
-              <Card.Footer className="bg-transparent border-0 p-4">
-                <div className="d-flex gap-3">
-                  <Button variant="primary" onClick={handleEdit} disabled={deleting}>
-                    <Icon name="write" size={16} className="me-2" />
-                    Edit Post
-                  </Button>
-                  <Button variant="outline-danger" onClick={() => setShowDeleteModal(true)} disabled={deleting}>
-                    <Icon name="alert" size={16} className="me-2" />
-                    Delete Post
-                  </Button>
-                </div>
-              </Card.Footer>{' '}
+              {getCurrentUserId() === post.rare_user_id.id ? (
+                <Card.Footer className="bg-transparent border-0 p-4">
+                  <div className="d-flex gap-3">
+                    <Button variant="primary" onClick={handleEdit} disabled={deleting}>
+                      <Icon name="write" size={16} className="me-2" />
+                      Edit Post
+                    </Button>
+                    <Button variant="outline-danger" onClick={() => setShowDeleteModal(true)} disabled={deleting}>
+                      <Icon name="alert" size={16} className="me-2" />
+                      Delete Post
+                    </Button>
+                  </div>
+                </Card.Footer>
+              ) : ''}
             </Card>
 
             {/* Comments Section */}

--- a/pages/posts/index.js
+++ b/pages/posts/index.js
@@ -1,5 +1,6 @@
 import Icon from '@/components/Icon';
 import { getPosts } from '@/utils/data/postData';
+import { getCurrentUserId } from '@/utils/data/AuthManager';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -168,10 +169,13 @@ function PostsHome() {
                       <Icon name="trending" size={16} className="me-1" />
                       View
                     </Button>
-                    <Button variant="outline-secondary" size="sm" onClick={() => handleEditPost(post.id)} className="flex-fill">
-                      <Icon name="write" size={16} className="me-1" />
-                      Edit
-                    </Button>
+                    {console.warn('current user id:', getCurrentUserId(), ' post.rare_user_id:', post.rare_user_id.id)}
+                    {getCurrentUserId() === post.rare_user_id.id ? (
+                      <Button variant="outline-secondary" size="sm" onClick={() => handleEditPost(post.id)} className="flex-fill">
+                        <Icon name="write" size={16} className="me-1" />
+                        Edit
+                      </Button>
+                    ) : ''}
                   </div>
                 </div>
               </Col>


### PR DESCRIPTION
Edited the return statements on `posts/index.js` and `posts/[id].js` so that if the logged in user's ID does not match the ID of the user who created the post, the edit and delete buttons do not appear.

There is still a vulnerability in which the user could enter `posts/edit/[id]` into the url and access the post that way 